### PR TITLE
anyio

### DIFF
--- a/srcpkgs/python3-anyio/template
+++ b/srcpkgs/python3-anyio/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-anyio'
 pkgname=python3-anyio
-version=4.3.0
+version=4.4.0
 revision=1
 build_style=python3-pep517
 # This file needs python module `exceptiongroup`
@@ -15,7 +15,18 @@ license="MIT"
 homepage="https://github.com/agronholm/anyio"
 changelog="https://raw.githubusercontent.com/agronholm/anyio/master/docs/versionhistory.rst"
 distfiles="${PYPI_SITE}/a/anyio/anyio-${version}.tar.gz"
-checksum=f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6
+checksum=5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94
+
+if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
+	# these tests fail on CI
+	_test1="(TestTCPListener)and(-ipv6)"
+	_test2="(test_iterate)or(test_extra)or(test_reuse)or(test_send_receive)"
+	_test2="(TestUDPSocket)and($_test2)and(-ipv6)"
+	_test3="(test_iterate)or(test_receive)or(test_reuse)or(test_send)"
+	_test3="(TestConnectedUDPSocket)and($_test3)and(-ipv6)"
+	_test4="test_bind_link_local"
+	make_check_args+=" -k not(($_test1)or($_test2)or($_test3)or($_test4))"
+fi
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	# getaddrinfo() always returns canonname in musl 1.1

--- a/srcpkgs/python3-anyio/template
+++ b/srcpkgs/python3-anyio/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-anyio'
 pkgname=python3-anyio
-version=4.4.0
+version=4.3.0
 revision=1
 build_style=python3-pep517
 # This file needs python module `exceptiongroup`
@@ -15,18 +15,7 @@ license="MIT"
 homepage="https://github.com/agronholm/anyio"
 changelog="https://raw.githubusercontent.com/agronholm/anyio/master/docs/versionhistory.rst"
 distfiles="${PYPI_SITE}/a/anyio/anyio-${version}.tar.gz"
-checksum=5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94
-
-if [ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ]; then
-	# these tests fail on CI
-	_test1="(TestTCPListener)and(-ipv6)"
-	_test2="(test_iterate)or(test_extra)or(test_reuse)or(test_send_receive)"
-	_test2="(TestUDPSocket)and($_test2)and(-ipv6)"
-	_test3="(test_iterate)or(test_receive)or(test_reuse)or(test_send)"
-	_test3="(TestConnectedUDPSocket)and($_test3)and(-ipv6)"
-	_test4="test_bind_link_local"
-	make_check_args+=" -k not(($_test1)or($_test2)or($_test3)or($_test4))"
-fi
+checksum=f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	# getaddrinfo() always returns canonname in musl 1.1

--- a/srcpkgs/python3-anyio/template
+++ b/srcpkgs/python3-anyio/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-anyio'
 pkgname=python3-anyio
 version=4.3.0
-revision=1
+revision=2
 build_style=python3-pep517
 # This file needs python module `exceptiongroup`
 make_check_args="--ignore tests/test_taskgroups.py"


### PR DESCRIPTION
- **flowblade: update to 2.16.3**
- **New package: python3-libusb1-3.1.0**
- **libshout-idjc: update to 2.4.6+1.**
- **idjc: update to 0.9.8.**
- **nv-codec-headers: update to 12.0.16.1**
- **ffmpeg: remove bin packages**
- **New package: ffmpeg6-6.0.1**
- **cmake-bootstrap: update to 3.30.1.**
- **cmake: update to 3.30.1.**
- **qt6-base: fix  CVE-2024-39936**
- **librime: update to 1.11.2.**
- **brise: rebuild for librime**
- **ibus-rime: rebuild for librime**
- **xcb-imdkit: update to 1.0.9.**
- **fcitx5: update to 5.1.10.**
- **fcitx5-chewing: update to 5.1.5.**
- **fcitx5-configtool: update to 5.1.6.**
- **fcitx5-chinese-addons: update to 5.1.6.**
- **fcitx5-hangul: update to 5.1.4.**
- **fcitx5-rime: update to 5.1.8.**
- **fcitx5-table-extra: update to 5.1.6.**
- **libime: update to 1.1.8.**
- **libime-jyutping: update to 1.0.12.**
- **fcitx5-table-other: update to 5.1.3.**
- **unpaper: update to 7.0.0.**
- **cmus: update to 2.11.0, adopt**
- **handbrake: update to 1.6.1**
- **New package: spex-x replaces spek-alternative for ffmpeg6**
- **xone: orphan.**
- **guvcview: revbump for ffmpeg6**
- **python3-pyinfra: update to 3.0.1.**
- **obs: update to 30.2.0.**
- **ntpd-rs: update to 1.2.3**
- **opensc: update to 0.25.1.**
- **pkcs11-helper: update to 1.30.0.**
- **qtav: remove package from srcpkgs**
- **zig: update to 0.13.0**
- **common/build_style/zig-build.sh: update for zig 0.13**
- **ncdu2: update to 2.4**
- **waylock: update to 1.2.0**
- **zls: update to 0.13.0**
- **river: update to 0.3.4**
- **linuxwave: patch to build with zig 0.12**
- **LuaJIT: update to 2.1.1720049189, cleanup, adopt.**
- **drumkv1: update to 1.0.0.**
- **padthv1: update to 1.0.0.**
- **samplv1: update to 1.0.0.**
- **synthv1: update to 1.0.0.**
- **discord: update to 0.0.61**
- **ffmpegthumbs: revbump for ffmpeg6**
- **ffmpegthumbnailer: revbump for ffmpeg6**
- **gst-rtsp-server: revbump for ffmpeg6**
- **gst-plugins-bad1: revbump for ffmpeg6**
- **gst-libav: revbump for ffmpeg6**
- **alsa-plugins: revbump for ffmpeg6**
- **chromaprint: revbump for ffmpeg6**
- **libopenal: revbump for ffmpeg6**
- **openimageio: revbump for ffmpeg6**
- **blender: revbump for ffmpeg6**
- **mpv: revbump for ffmpeg6**
- **mlt7: revbump for ffmpeg6**
- **shotcut: revbump for ffmpeg6**
- **obs: revbump for ffmpeg6**
- **mpd: revbump for ffmpeg6**
- **cantata: revbump for ffmpeg6**
- **mixxx: revbump for ffmpeg6**
- **kid3: revbump for ffmpeg6**
- **telegram-desktop: revbump for ffmpeg6**
- **tg_owt: revbump for ffmpeg6**
- **vba-m: revbump for ffmpeg6**
- **dolphin-emu: revbump for ffmpeg6**
- **gamescope: update to 3.14.24.**
- **New package: cloud-utils-0.33.**
- **cmatrix: fix kana output**
- **New package: clojure-lsp-2024.04.22**
- **clojure-lsp: fix build**
- **New package: swayr-0.27.3**
- **New package: swayrbar-0.3.8**
- **New package: soft-serve-0.7.4**
- **New package: treefmt-2.0.1**
- **New package: python3-pillow_heif-0.17.0**
- **New package: stegseek-0.6**
- **New package: typstyle-0.11.28**
- **New package: swaysome-2.1.1.**
- **New package: efm-langserver-0.0.52**
- **handbrake: add changelog**
- **i2pd: update to 2.53.0**
- **strawberry: update to 1.1.1**
- **obs: update to 30.2.1.**
- **New package: cpufetch-1.05**
- **php8.1: update to 8.1.29.**
- **php8.1-mongodb: update to 1.19.3.**
- **composer8.1: update to 2.7.7.**
- **New package: php8.1-redis-6.0.2**
- **php8.2: update to 8.2.21.**
- **php8.2-mongodb: update to 1.19.3.**
- **composer8.2: update to 2.7.7.**
- **New package: php8.2-redis-6.0.2**
- **php8.3: update to 8.3.9.**
- **php8.3-mongodb: update to 1.19.3.**
- **composer8.3: update to 2.7.7.**
- **New package: php8.3-redis-6.0.2**
- **arduino-cli: update to 1.0.3.**
- **python3-cryptography_vectors: update to 43.0.0.**
- **python3-cryptography: update to 43.0.0.**
- **python3-aiostream: update to 0.6.2.**
- **python3-pure_eval: update to 0.2.3.**
- **python3-tifffile: update to 2024.7.21.**
- **python3-setuptools: update to 71.1.0.**
- **python3-pyFFTW: update to 0.14.0.**
- **python3-pytools: update to 2024.1.11.**
- **clojure-lsp: set graal as java distribution**
- **wike: update to 3.0.1**
- **gping: update to 1.17.3.**
- **vhs: depend on ffmpeg6**
- **New package: UxPlay-1.68.3**
- **Tuba: update to 0.8.2.**
- **wlogout: update to 1.2.2**
- **MoarVM: update to 2024.06, build with mimalloc.**
- **nqp: update to 2024.06.**
- **rakudo: update to 2024.06.**
- **nvidia-vaapi-driver: update to 0.0.12.**
- **nim: update to 2.0.8.**
- **nvidia-container-toolkit: update to 1.12.0**
- **libnvidia-container: update to 1.12.0**
- **New package: xq-1.2.4**
- **New package: python3-mautrix-0.20.2.**
- **New package: heisenbridge-1.14.6.**
- **river: update to 0.3.5.**
- **libvirt: update to 10.5.0.**
- **libvirt-python3: update to 10.5.0.**
- **qemu: update to 9.0.2.**
- **qemu-user-static: update to 9.0.2.**
- **zoom: update to 6.1.5.871**
- **cloud-guest-utils: add core-service for resizing rootfs**
- **shotman: update to 0.4.6.**
- **librsvg: update to 2.58.2.**
- ***: update my email**
- **libbreeze-icons: split from breeze-icons**
- **kf6-kiconthemes: rebuild with split libbreeze-icons**
- **libsecret: update to 0.21.4**
- **RyzenAdj: update to 0.15.0.**
- **ruby-build: update to 20240722**
- **New package: libdispatch-5.10.1**
- **deadbeef: update to 1.9.6**
- **cmatrix: fix Japanese**
- **openmw: fix build**
- **Revert "cmatrix: fix Japanese"**
- **neovim: update to 0.10.1**
- **mandrel: update to 23.1.4.0.**
- **way-displays: update to 1.11.0.**
- **rbenv: update to 1.3.0**
- **SPIRV-Headers: update to 1.3.290.0.**
- **SPIRV-Tools: update to 2024.3.**
- **uni: update to 2.7.0.**
- **bemenu: update to 0.6.23**
- **just: update to 1.32.0**
- **wstunnel: update to 9.7.4**
- **openssl: update homepage, distfile url**
- **libssl1.1: update homepage, distfile url**
- **Waybar: update to 0.10.4**
- **python3-pluggy: update to 1.5.0.**
- **chromium: update to 127.0.6533.72.**
- **qemu-user-static: fix binfmt generation on cross**
- **obs: fix double-free on exit**
- **python3-openssl: update to 24.2.1.**
- **fortune-mod-void: add fortune.**
- **python3-ytmusicapi: update to 1.8.0.**
- **NetworkManager: update to 1.48.4**
- **NetworkManager-openvpn: update to 1.12.0**
- **webrtc-audio-processing: fix for i686-musl build**
- **calibre: update to 7.15.0.**
- **benchmark: update to 1.8.5.**
- **python3-regex: update to 2024.7.24.**
- **btrfs-progs: update to 6.9.2.**
- **swayimg: update to 2.5.**
- **orc: update to 0.4.39**
- **mercurial: update to 6.8.**
- **libosmgpsmap: port to libsoup-3.0**
- **darktable: update to 4.8.1.**
- **fastfetch: update to 2.19.1.**
- **pyright: update to 1.1.373.**
- **uv: update to 0.2.29.**
- **yt-dlp: update to 2024.07.25.**
- **podman: update to 5.1.2.**
- **ncdc: update to 1.24.1**
- **difftastic: update to 0.59.0.**
- **ncdu2: update to 2.5**
- **curl: update to 8.9.0**
- **hyperrogue: update to 13.0s**
- **gopass: run tests, remove useless paths, build as pie**
- **terragrunt: update to 0.63.6.**
- **moby: update to 27.1.1.**
- **docker-cli: update to 27.1.1.**
- **hugo: update to 0.129.0.**
- **hopper: update to 5.16.0.**
- **flannel: update to 0.25.5.**
- **c-ares: update to 1.32.3.**
- **flatpak: update to 1.15.9.**
- **knot-resolver: update to 5.7.4.**
- **linux6.10: update to 6.10.1.**
- **firefox: update to 128.0.2.**
- **firefox-i18n: update to 128.0.2.**
- **dbeaver: update to 24.1.3.**
- **gnome-sudoku: update to 46.3.**
- **strace: update to 6.10.**
- **chirp: update to 20240706.**
- **croc: update to 10.0.10**
- **rust-analyzer: update to 2024.07.22.**
- **cargo-modules: update to 0.16.6.**
- **tflint: update to 0.52.0**
- **libwaylandpp: update to 1.0.0**
- **kodi: update to 21.0**
- **New package: erlang_ls-0.52.0**
- **ruby-tmuxinator: fix naming of completion file**
- **zsh-completions: remove tmuxinator**
- **linux6.9: update to 6.9.11.**
- **linux6.6: update to 6.6.42.**
- **linux6.1: update to 6.1.101.**
- **libavif: add missing libaom dependecy to -devel**
- **awsume: update to 4.5.5.**
- **bmake: update to 20240711.**
- **graphviz: update to 12.0.0.**
- **gucci: update to 1.6.13.**
- **nncp: update to 8.11.0.**
- **parallel: update to 20240722.**
- **python3-drgn: update to 0.0.27.**
- **ldns: update to 1.8.4.**
- **swi-prolog: update to 9.2.6.**
- **libjxl: add missing highway dependency to -devel**
- **New package: grpcurl-1.9.1**
- **New package: opentofu-1.7.3**
- **afl++: build with llvm18, add aarch64**
- **libmirage: update to 3.2.8.**
- **chafa: update to 1.14.2**
- **circadian: update time-rs for rust 1.80**
- **delta: update time-rs for rust 1.80**
- **evtx: update time-rs for rust 1.80**
- **ldns: broken on i686 for now**
- **fastfetch: update to 2.20.0.**
- **uv: update to 0.2.30.**
- **turnstile: update to 0.1.9.**
- **rpi-eeprom: update to 2024.07.25.**
- **rpi-firmware: update to 20240725.**
- **rpi-kernel: update to 6.6.42.**
- **ldc: update to 1.39.0**
- **btdu: rebuild for ldc**
- **gtkd: rebuild for ldc**
- **onedrive: rebuild for ldc**
- **tilix: rebuild for ldc**
- **limine: update to 7.12.1.**
- **hwloc: update to 2.10.0.**
- **fzf: update to 0.54.2.**
- **scite: update to 5.5.1.**
- **ldns: try disable_parallel_build.**
- **DarkRadiant: update to 3.9.0.**
- **baresip: update to 3.14.0.**
- **re: update to 3.14.0.**
- **scummvm: update to 2.8.1.**
- **python: unbreak hashlib**
- **rootlesskit: update to 2.2.0.**
- **bluedevil: update to 6.1.3.**
- **breeze-gtk: update to 6.1.3.**
- **breeze-qt5: update to 6.1.3.**
- **breeze-qt6: update to 6.1.3.**
- **drkonqi: update to 6.1.3.**
- **flatpak-kcm: update to 6.1.3.**
- **kactivitymanagerd: update to 6.1.3.**
- **kcm-wacomtablet: update to 6.1.3.**
- **kde-cli-tools: update to 6.1.3.**
- **kde-gtk-config: update to 6.1.3.**
- **kdeplasma-addons: update to 6.1.3.**
- **kf6-kdecoration: update to 6.1.3.**
- **kf6-kwayland: update to 6.1.3.**
- **kgamma: update to 6.1.3.**
- **kglobalacceld: update to 6.1.3.**
- **kinfocenter: update to 6.1.3.**
- **kmenuedit: update to 6.1.3.**
- **kpipewire: update to 6.1.3.**
- **krdp: update to 6.1.3.**
- **kscreen: update to 6.1.3.**
- **kscreenlocker: update to 6.1.3.**
- **ksshaskpass: update to 6.1.3.**
- **ksystemstats: update to 6.1.3.**
- **kwallet-pam: update to 6.1.3.**
- **kwayland-integration: update to 6.1.3.**
- **kwin: update to 6.1.3.**
- **kwrited: update to 6.1.3.**
- **layer-shell-qt: update to 6.1.3.**
- **libkf6screen: update to 6.1.3.**
- **libksysguard: update to 6.1.3.**
- **libplasma: update to 6.1.3.**
- **milou: update to 6.1.3.**
- **oxygen-qt5: update to 6.1.3.**
- **oxygen-qt6: update to 6.1.3.**
- **oxygen-sounds: update to 6.1.3.**
- **plasma-activities-stats: update to 6.1.3.**
- **plasma-activities: update to 6.1.3.**
- **plasma-browser-integration: update to 6.1.3.**
- **plasma-desktop: update to 6.1.3.**
- **plasma-disks: update to 6.1.3.**
- **plasma-firewall: update to 6.1.3.**
- **plasma-integration: update to 6.1.3.**
- **plasma-nm: update to 6.1.3.**
- **plasma-pa: update to 6.1.3.**
- **plasma-sdk: update to 6.1.3.**
- **plasma-systemmonitor: update to 6.1.3.**
- **plasma-thunderbolt: update to 6.1.3.**
- **plasma-vault: update to 6.1.3.**
- **plasma-workspace-wallpapers: update to 6.1.3.**
- **plasma-workspace: update to 6.1.3.**
- **plasma5support: update to 6.1.3.**
- **polkit-kde-agent: update to 6.1.3.**
- **powerdevil: update to 6.1.3.**
- **print-manager: update to 6.1.3.**
- **sddm-kcm: update to 6.1.3.**
- **systemsettings: update to 6.1.3.**
- **xdg-desktop-portal-kde: update to 6.1.3.**
- **linux6.10: update to 6.10.2.**
- **linux6.6: update to 6.6.43.**
- **linux6.9: update to 6.9.12.**
- **man-pages-posix: rebuild to fix corrupted manpage(s)**
- **linux6.9: add checksums**
- **Revert "ldns: try disable_parallel_build."**
- **minify: update to 2.20.37.**
- **ocaml-zarith: update to 1.14.**
- **ocamlbuild: update to 0.15.0.**
- **ntdsextract2: pin term-table to older version**
- **wiki-tui: update time-rs for rust 1.80**
- **sabnzbd: update to 4.3.2.**
- **New package: python3-sabctools-8.2.4**
- **New package: python3-apprise-1.8.1**
- **avidemux: update to 2.8.1**
- **idjc: revbump for ffmpeg6**
- **libopenshot: revbump for ffmpeg6**
- **openshot: revbump for ffmpeg6**
- **synfig: revbump for ffmpeg6 and mlt7**
- **synfigstudio: revbump for ffmpeg6**
- **mlt: remove package**
- **xine-lib: update to 1.2.13.**
- **osg: revbump for ffmpeg6**
- **openmw: revbump for ffmpeg6**
- **sumo: revbump for ffmpeg6**
- **vice: revbump for ffmpeg6**
- **retroarch: revbump for ffmpeg6**
- **ppsspp: revbump for ffmpeg6**
- **hedgewars: revbump for ffmpeg6**
- **mgba: revbump for ffmpeg6**
- **goldendict: revbump for ffmpeg6**
- **kpipewire: revbump for ffmpeg6**
- **kfilemetadata5: revbump for ffmpeg6**
- **kf6-kfilemetadata: revbump for ffmpeg6**
- **kf6-kcoreadds: revbump for kf6-kfilemetadata**
- **ssr: revbump for ffmpeg6**
- **QMPlay2: revbump for ffmpeg6**
- **audacious-plugins: revbump for ffmpeg6**
- **qmmp: revbump for ffmpeg6**
- **notcurses: revbump for ffmpeg6**
- **timg: revbump for ffmpeg6**
- **pianobar: revbump for ffmpeg6**
- **loudgain: revbump for ffmpeg6**
- **ffms2: revbump for ffmpeg6**
- **cyanrip: revbump for ffmpeg6**
- **ccextractor: revbump for ffmpeg6**
- **aubio: revbump for ffmpeg6**
- **attract: revbump for ffmpeg6**
- **musikcube: revbump for ffmpeg6**
- **baresip: revbump for ffmpeg6**
- **lms: revbump for ffmpeg6**
- **droidcam-obs-plugin: revbump for ffmpeg6**
- **droidcam: revbump for ffmpeg6**
- **gerbera: revbump for ffmpeg6**
- **pqiv: revbump for ffmpeg6**
- **siril: revbump for ffmpeg6**
- **tracker-miners: revbump for ffmpeg6**
- **minidlna: revbump for ffmpeg6**
- **motion: revbump for ffmpeg6**
- **scrcpy: revbump for ffmpeg6**
- **wf-recorder: revbump for ffmpeg6**
- **waypipe: revbump for ffmpeg6**
- **xpra: revbump for ffmpeg6**
- **arcan: revbump for ffmpeg6**
- **freerdp3: revbump for ffmpeg6**
- **freerdp: revbump for ffmpeg6**
- **retroshare: revbump for ffmpeg6**
- **mpv-mpris: rebuild for ffmpeg6**
- **opencv: rebuild for ffmpeg6**
- **qt6-multimedia: rebuild for ffmpeg6**
- **qt5: rebuild for ffmpeg6**
- **qtox: rebuild for ffmpeg6**
- **terraform: update to 1.9.3.**
- **terragrunt: update to 0.64.1.**
- **git-cola: update to 4.8.1.**
- **llvm15: remove package.**
- **libtracefs: update to 1.8.1.**
- **libtraceevent: update to 1.8.3.**
- **trace-cmd: update to 3.3.**
- **libX11: update to 1.8.10.**
- **sbcl: update to 2.4.7.**
- **yaydl: update to 0.14.1**
- **kubernetes: update to 1.30.3.**
- **embree: update to 4.3.3.**
- **mesa: update to 24.1.4**
- **ffmpeg6: adding patches for mesa 24.1.4**
- **rust-bootstrap: update to 1.80.0**
- **cargo-bootstrap: update to 1.80.0**
- **rust: update to 1.80.0**
- **cargo: update to 1.80.0**
- **spotifyd: fix ftbfs**
- **spotify-tui: fix ftbfs**
- **spotifyd: bump time dependency**
- **turnstile: update to 0.1.10.**
- **qscintilla-qt5: fix build**
- **nss: update to 3.102.1.**
- **git: update to 2.46.0.**
- **ast-grep: update to 0.25.4.**
- **vale: update to 3.7.0.**
- **trash-cli: update to 0.24.5.26.**
- **exiftool: update to 12.92**
- **ruff: update to 0.5.5, add completions**
- **gscreenshot: update to 3.6.2.**
- **cyanrip: update to 0.9.3.1.**
- **typioca: update to 3.0.0.**
- **treefmt: update to 2.0.3.**
- **efm-langserver: update to 0.0.53.**
- **wvkbd: update to 0.15.**
- **tuxedo-drivers: update to 4.6.1**
- **bottom: update to 0.9.7**
- **moar: update to 1.25.1**
- **procs: update to 0.14.6**
- **starship: update to 1.20.1**
- **mdcat: update to 2.3.0**
- **blueman: update to 2.4.3**
- **libjodycode: update to 3.1.1**
- **jdupes: update to 1.28.0**
- **nushell: update to 0.96.1**
- **wine: Update to 9.14**
- **halloy: update to 2024.9**
- **yquake2: update to 8.40.**
- **ruby-build: update to 20240727**
- **qmk: update to 1.1.5.**
- **claws-mail: update to 4.3.0**
- **discord: update to 0.0.62**
- **qt5-webengine: revbump for ffmpeg6**
- **hugo: update to 0.130.0.**
- **terragrunt: update to 0.64.4.**
- **qt6-pdf: revbump for ffmpeg6**
- **passt: update to 2024.07.26.57a21d2.**
- **smcroute: update to 2.5.7.**
- **qt5-webengine: use vendored re2**
- **python3-pyqt6: update to 6.7.1.**
- **New package: qscintilla-qt6-2.14.1**
- **New package: python3-pyqt6-qsci-2.14.1**
- **backblaze-b2: update to 4.1.0.**
- **packer: update to 1.11.2.**
- **python3-b2sdk: update to 2.5.0.**
- **pylint: update to 3.2.6**
- **newsboat: update to 2.36.**
- **containers-common: update to 0.60.0**
- **containers.image: update to 5.32.0**
- **containers.storage: update to 1.55.0**
- **buildah: update to 1.37.0**
- **skopeo: update to 1.16.0**
- **podman-tui: update to 1.1.0**
- **zoom: update to 6.1.6.1013**
- **nerd-fonts: update to 3.2.1**
- **gocloc: update to 0.5.2**
- **swaybg: update to 1.2.1**
- **just: update to 1.33.0**
- **taplo: update to 0.9.3**
- **syft: update to 1.10.0**
- **python3-openpyxl: update to 3.1.3.**
- **osc: update to 1.8.3**
- **nasa-wallpaper: update to 2.1.1**
- **gstreamer1: update to 1.24.6**
- **gst-plugins-base1: update to 1.24.6**
- **gst-plugins-good1: update to 1.24.6**
- **gst-plugins-bad1: update to 1.24.6**
- **gst-plugins-ugly1: update to 1.24.6**
- **gstreamer-vaapi: update to 1.24.6**
- **gst-libav: update to 1.24.6**
- **gst-rtsp-server: update to 1.24.6**
- **gst1-editing-services: update to 1.24.6**
- **gst1-python3: update to 1.24.6**
- **mozjs102: build with llvm18, broken.**
- **ghdl: update to 4.1.0.**
- **knot: update to 3.3.8.**
- **llvm12: remove package**
- **codeberg-cli: update to 0.4.3**
- **rio: update to 0.1.3**
- **python3-numpy: update to 2.0.1.**
- **common/build-helper/numpy.sh: update paths for python3-numpy>=2.0.0**
- **gnuradio: rebuild against python3-numpy**
- **mypaint: rebuild against python3-numpy**
- **opencv: rebuild against python3-numpy**
- **plplot: rebuild against python3-numpy**
- **python3-Bottleneck: update to 1.4.0.**
- **python3-PyOpenGL-accelerate: rebuild without python3-numpy**
- **python3-h5py: rebuild against python3-numpy**
- **python3-joblib: update to 1.4.2.**
- **python3-matplotlib: rebuild against python3-numpy**
- **python3-numexpr: update to 2.10.1.**
- **python3-numpy-stl: rebuild against python3-numpy**
- **python3-pandas: update to 2.2.2.**
- **python3-pyFFTW: rebuild against python3-numpy**
- **python3-pycollada: update to 0.8.**
- **python3-pyopencl: rebuild against python3-numpy**
- **python3-pyqtgraph: update to 0.13.7.**
- **python3-pywt: rebuild against python3-numpy**
- **pythran: fix required gast version**
- **python3-scikit-image: rebuild against python3-numpy**
- **python3-scikit-learn: update to 1.5.0.**
- **python3-scipy: rebuild against python3-numpy**
- **python3-seaborn: update to 0.13.2.**
- **python3-shapely: update to 2.0.5.**
- **python3-tables: rebuild against python3-numpy**
- **python3-trimesh: update to 4.4.3.**
- **python3-vispy: rebuild against python3-numpy**
- **sagemath: reubild against python3-numpy**
- **urh: rebuild against python3-numpy**
- **wxPython: fix runtime dependencies**
- **tuxedo-drivers: fix building on kernel 6.10**
- **lite-xl: enable SDL renderer**
- **picard: update to 2.12**
- **Signal-Desktop: update to 7.17.0.**
- **fwupd: update to 1.9.22.**
- **hackrf: update to 2024.02.1**
- **dasel: update to 2.8.1.**
- **font-sarasa-gothic: update to 1.0.16.**
- **python3-nbxmpp: update to 5.0.3.**
- **gajim: update to 1.9.3.**
- **limine: update to 7.13.2.**
- **shotman: update to 0.4.7, adopt**
- **z3: split into z3, libz3, z3-devel**
- **llvm18: use z3-devel (no rebuild)**
- **python3-rapidfuzz: update to 3.9.5**
- **dnsdist: update to 1.9.6**
- **python3-textual: update to 0.73.0.**
- **memray: update to 1.13.4.**
- **tree: update to 2.1.3.**
- **restic: update to 0.17.0.**
- **j4-dmenu-desktop: update to 3.1.**
- **swirc: update to 3.4.9.**
- **instaloader: update to 4.12.1**
- **Gokapi: update to 1.9.1.**
- **rbw: update to 1.12.1.**
- **python3-bokeh: update to 3.5.1.**
- **python3-aiohappyeyeballs: update to 2.3.4.**
- **python3-pip: update to 24.2.**
- **python3-scikit-build-core: update to 0.9.9.**
- **python3-redis: update to 5.0.9.**
- **python3-tifffile: update to 2024.7.24.**
- **python3-setuptools: update to 72.1.0.**
- **python3-mpi4py: update to 4.0.0.**
- **nvidia: update to 550.107.02**
- **vimiv: no needs python3-devel in hostmakedepends**
- **bpftop: update to 0.5.2.**
- **maildrop: update to 3.1.7.**
- **ugrep: update to 6.3.0.**
- **nodejs: update to 20.16.0.**
- **Rocket.Chat: rebuild for new nodejs version**
- **Signal-Desktop: rebuild for new nodejs version**
- **trurl: update to 0.14.**
- **synapse: update to 1.112.0.**
- **bottom: update to 0.10.0**
- **grype: update to 0.79.4**
- **yq-go: update to 4.44.2**
- **NetworkManager: update to 1.48.6**
- **Thunar: update to 4.18.11**
- **pipewire: update to 1.2.2**
- **docker-compose: update to 2.29.1**
- **docker-gen: update to 0.14.1.**
- **ntdsextract2: update to 1.2.2.**
- **python3-Pyphen: update to 0.16.0.**
- **spicy: update to 1.11.0.**
- **gcc6: missing dependency in hostmakedepends**
- **noto-fonts-ttf: update to 24.8.1.**
- **vivaldi: update to 6.8.3381.50+1.**
- **yt-dlp: update to 2024.08.01.**
- **github-cli: update to 2.54.0**
- **apache-maven: update to 3.9.8.**
- **apt: update to 2.9.7.**
- **dpkg: update to 1.22.10.**
- **sysstat: update to 12.7.6.**
- **bcc: update to 0.31.0.**
- **debootstrap: update to 1.0.137.**
- **fzf: update to 0.54.3.**
- **libavif: update to 1.1.1.**
- **mpop: update to 1.4.20.**
- **perl-Mozilla-CA: update to 20240730.**
- **ksh: update to 1.0.10.**
- **stress-ng: update to 0.18.02.**
- **libavif: fix checksum**
- **foot: update to 1.18.0.**
- **zeek: update to 7.0.0.**
- **incus: make check script executable**
- **sndio: update to 1.10.0.**
- **common/environment/setup/install.sh: chmod all executable files in vsv**
- ***: remove executable perms on service files in-tree**
- ***: remove unnecessary execute permissions**
- **incus: fix check script**
- **calibre: update to 7.16.0.**
- **terragrunt: update to 0.66.0.**
- **hugo: update to 0.131.0.**
- **terragrunt: update to 0.66.1.**
- **telegram-desktop: update to 5.3.2.**
- **tg_owt: update to 0.0.0.20240821.**
- **New package: openh264-2.4.1**
- **New package: ada-2.9.0**
- **cloc: update to 2.02.**
- **gleam: update to 1.4.0.**
- **isync: update to 1.5.0.**
- **nawk: update to 20240728.**
- **nsd: update to 4.10.1.**
- **leftwm: update to 0.5.1.**
- **linux6.10: update to 6.10.3.**
- **fwupd: add changelog**
- **limine: update to 8.0.0.**
- **nuspell: update to 5.1.6.**
- **New package: scenefx-0.1**
- **swayfx: update to 0.4.**
- **eza: update to 0.18.24**
- **xbps-triggers: make executable again**
- **linux6.10: rebuild for hooks**
- **spotify: update to 1.2.42.**
- **libheif: update to 1.18.1**
- **python3-Faker: update to 26.1.0.**
- **yazi: update to 0.3.0.**
- **font-sarasa-gothic: update to 1.0.17.**
- **qarma: update for qt6**
- **gopass: update to 1.15.14.**
- **inspircd: update to 4.2.0**
- **drm_info: update to 2.7.0**
- **rust-analyzer: update to 2024.07.29.**
- **Signal-Desktop: update to 7.18.0.**
- **links: update to 2.30**
- **links-x11: update to 2.30**
- **opentofu: update to 1.8.0.**
- **arpwatch: update to 3.6.**
- **tiff: enable webp support**
- **typstyle: update to 0.11.30.**
- **qarma: mark broken for now**
- **cargo-update: update to 13.4.0**
- **llhttp: update to 9.2.1**
- **New package: libgit2-1.8-1.8.1**
- **libgit2: provide virtual packages for conflicts, drop cli**
- **eza: rebuild for libgit2-1.8**
- **git-cliff: rebuild for libgit2-1.8**
- **codeberg-cli: rebuild for libgit2-1.8**
- **tiff: fix cycle by disabling webp support by default**
- **libwebp: fix -devel depends**
- **qarma: unbreak**
- **Bear: update to 3.1.4.**
- **clazy: update to 1.12.**
- **corrosion: update to 0.5.0.**
- **hwids: update to 0.384.**
- **lolcat-c: update to 1.5.**
- **tg_owt: disable update check**
- **libbpf-devel: need elfutils-devel.**
- **python3-colored-traceback: update to 0.4.2.**
- **bottom: update to 0.10.1**
- **broot: update to 1.41.1**
- **just: update to 1.34.0**
- **mdcat: update to 2.3.1**
- **ttyplot: update to 1.7.0**
- **New package: nng-1.5.2**
- **New package: SatDump-1.2.0**
- **halloy: update to 2024.10**
- **swayimg: update to 3.0.**
- **cpuid: update to 20240716.**
- **hcloud: update to 1.46.0.**
- **rest-server: update to 0.13.0.**
- **pgmetrics: update to 1.17.0.**
- **dbeaver: update to 24.1.4.**
- **MoarVM: update to 2024.07.**
- **nqp: update to 2024.07.**
- **rakudo: update to 2024.07.**
- **OpenRCT2: update to 0.4.13.**
- **pyright: update to 1.1.374.**
- **uv: update to 0.2.33.**
- **fastfetch: update to 2.21.0.**
- **gopass-jsonapi: update to 1.15.14**
- **limine: update to 8.0.1.**
- **arcan: update to 0.6.3.3.**
- **xarcan: update to 0.6.3.**
- **aclip: update to 0.6.3.3.**
- **acfgfs: update to 0.6.3.3.**
- **aloadimage: update to 0.6.3.3.**
- **python3-anyio: update to 4.4.0.**

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
